### PR TITLE
Add Password Reuse Policy feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,12 @@ REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+
+ifeq ($(MAJORVERSION),$(filter $(MAJORVERSION), 14 15))
+	REGRESS += 05_reuse_history
+	REGRESS += 06_reuse_interval
+else
+	REGRESS += 05_pg13_reuse_history
+	REGRESS += 06_pg13_reuse_interval
+endif
+

--- a/credcheck--1.0.0.sql
+++ b/credcheck--1.0.0.sql
@@ -1,0 +1,22 @@
+-- credcheck extension for PostgreSQL
+-- Copyright (c) 2021-2023 MigOps Inc - All rights reserved.
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION credcheck" to load this file. \quit
+
+CREATE SCHEMA credcheck;
+
+----
+-- Table used to store the password reuse historic
+----
+CREATE TABLE credcheck.pg_auth_history
+(
+	rolename name NOT NULL,
+	password_date timestamp without time zone NOT NULL,
+	password_text text NOT NULL,
+	PRIMARY KEY (rolename, password_text)
+);
+CREATE INDEX ON credcheck.pg_auth_history(password_date, rolename);
+
+-- Include the table into pg_dump
+SELECT pg_catalog.pg_extension_config_dump('credcheck.pg_auth_history', '');

--- a/credcheck.control
+++ b/credcheck.control
@@ -1,4 +1,4 @@
 comment = 'credcheck - postgresql plain text credential checker'
-default_version = '0.2.0'
+default_version = '1.0.0'
 module_pathname = '$libdir/credcheck'
-relocatable = true
+relocatable = false

--- a/test/expected/05_pg13_reuse_history.out
+++ b/test/expected/05_pg13_reuse_history.out
@@ -1,0 +1,42 @@
+DROP USER IF EXISTS credtest;
+NOTICE:  role "credtest" does not exist, skipping
+DROP EXTENSION credcheck CASCADE;
+CREATE EXTENSION credcheck;
+LOAD 'credcheck';
+SET credcheck.password_reuse_history = 2;
+-- When creating user the password must be stored in the history
+CREATE USER credtest WITH PASSWORD 'H8Hdre=S2';
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename |                          password_text                           
+----------+------------------------------------------------------------------
+ credtest | 5302ee28c0fde94ab3a23a6f660d5983bf8147397def105427d0f37e810c134c
+ credtest | c38cf85ca6c3e5ee72c09cf0bfb42fb29b0f0a3e8ba335637941d60f86512508
+(2 rows)
+
+-- fail, the credential is still in the history
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+ERROR:  Cannot use this credential following the password reuse policy
+-- eject the first credential from the history and add a new one
+ALTER USER credtest PASSWORD 'AJ8YuRe=6O0';
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename |                          password_text                           
+----------+------------------------------------------------------------------
+ credtest | c38cf85ca6c3e5ee72c09cf0bfb42fb29b0f0a3e8ba335637941d60f86512508
+ credtest | c0b37cb82bc2b8a2aae606362754072224fe01651aabc688c4aa240ab450f916
+(2 rows)
+
+-- fail, the credential is still in the history
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+ERROR:  Cannot use this credential following the password reuse policy
+-- success, eject the second credential from the history and reuse the first one
+ALTER USER credtest PASSWORD 'H8Hdre=S2';
+-- success, the second credential has been removed from the history
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+-- Dropping the user must empty the record in history table
+DROP USER credtest;
+SELECT * FROM credcheck.pg_auth_history;
+ rolename | password_date | password_text 
+----------+---------------+---------------
+(0 rows)
+

--- a/test/expected/05_reuse_history.out
+++ b/test/expected/05_reuse_history.out
@@ -1,0 +1,42 @@
+DROP USER IF EXISTS credtest;
+NOTICE:  role "credtest" does not exist, skipping
+DROP EXTENSION credcheck CASCADE;
+CREATE EXTENSION credcheck;
+LOAD 'credcheck';
+SET credcheck.password_reuse_history = 2;
+-- When creating user the password must be stored in the history
+CREATE USER credtest WITH PASSWORD 'H8Hdre=S2';
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename |                          password_text                           
+----------+------------------------------------------------------------------
+ credtest | 7488570b80076cf9da26644d5eeb316c4768ff5bee7bf319344e7bb328032098
+ credtest | e61e58c22aa6bf31a92b385932f7d0e4dbaba24fa3fdb2982510d6c72a961335
+(2 rows)
+
+-- fail, the credential is still in the history
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+ERROR:  Cannot use this credential following the password reuse policy
+-- eject the first credential from the history and add a new one
+ALTER USER credtest PASSWORD 'AJ8YuRe=6O0';
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename |                          password_text                           
+----------+------------------------------------------------------------------
+ credtest | e61e58c22aa6bf31a92b385932f7d0e4dbaba24fa3fdb2982510d6c72a961335
+ credtest | 79320cea69ba581d5e17255c02ae08060f412f79a7c14d0e24ffca51fc03ec74
+(2 rows)
+
+-- fail, the credential is still in the history
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+ERROR:  Cannot use this credential following the password reuse policy
+-- success, eject the second credential from the history and reuse the first one
+ALTER USER credtest PASSWORD 'H8Hdre=S2';
+-- success, the second credential has been removed from the history
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+-- Dropping the user must empty the record in history table
+DROP USER credtest;
+SELECT * FROM credcheck.pg_auth_history;
+ rolename | password_date | password_text 
+----------+---------------+---------------
+(0 rows)
+

--- a/test/expected/06_pg13_reuse_interval.out
+++ b/test/expected/06_pg13_reuse_interval.out
@@ -1,0 +1,72 @@
+DROP USER IF EXISTS credtest;
+NOTICE:  role "credtest" does not exist, skipping
+DROP EXTENSION credcheck CASCADE;
+CREATE EXTENSION credcheck;
+-- no password in the history, the extension has not been loaded
+CREATE USER credtest WITH PASSWORD 'AJ8YuRe=6O0';
+LOAD 'credcheck';
+SET credcheck.password_reuse_history = 1;
+SET credcheck.password_reuse_interval = 365;
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename | password_text 
+----------+---------------
+(0 rows)
+
+-- Add a new password in the history and set its age to 100 days
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+UPDATE credcheck.pg_auth_history SET password_date = now() - '100 days'::interval;
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename |                          password_text                           
+----------+------------------------------------------------------------------
+ credtest | c38cf85ca6c3e5ee72c09cf0bfb42fb29b0f0a3e8ba335637941d60f86512508
+(1 row)
+
+-- fail, the password is in the history for less than 1 year
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+ERROR:  Cannot use this credential following the password reuse policy
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename |                          password_text                           
+----------+------------------------------------------------------------------
+ credtest | c38cf85ca6c3e5ee72c09cf0bfb42fb29b0f0a3e8ba335637941d60f86512508
+(1 row)
+
+-- success, but the old password must be kept in the history (interval not reached)
+ALTER USER credtest PASSWORD 'AJ8YuRe=6O0';
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename |                          password_text                           
+----------+------------------------------------------------------------------
+ credtest | c38cf85ca6c3e5ee72c09cf0bfb42fb29b0f0a3e8ba335637941d60f86512508
+ credtest | c0b37cb82bc2b8a2aae606362754072224fe01651aabc688c4aa240ab450f916
+(2 rows)
+
+-- fail, the password is still present in the history
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+ERROR:  Cannot use this credential following the password reuse policy
+-- Change the age of the password to exceed the 1 year interval
+UPDATE credcheck.pg_auth_history SET password_date = now() - '380 days'::interval;
+-- success, the old password present in the history has expired
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename |                          password_text                           
+----------+------------------------------------------------------------------
+ credtest | c0b37cb82bc2b8a2aae606362754072224fe01651aabc688c4aa240ab450f916
+ credtest | c38cf85ca6c3e5ee72c09cf0bfb42fb29b0f0a3e8ba335637941d60f86512508
+(2 rows)
+
+-- Rename user, all entries in the history table must follow the change
+ALTER USER credtest RENAME TO credtest2;
+NOTICE:  MD5 password cleared because of role rename
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename  |                  password_text                   
+-----------+--------------------------------------------------
+ credtest2 | 0b37cb82bc2b8a2aae606362754072224fe01651aabc688c
+ credtest2 | 38cf85ca6c3e5ee72c09cf0bfb42fb29b0f0a3e8ba335637
+(2 rows)
+
+-- Dropping the user must empty the record in history table
+DROP USER credtest2;
+SELECT * FROM credcheck.pg_auth_history;
+ rolename | password_date | password_text 
+----------+---------------+---------------
+(0 rows)
+

--- a/test/expected/06_reuse_interval.out
+++ b/test/expected/06_reuse_interval.out
@@ -1,0 +1,71 @@
+DROP USER IF EXISTS credtest;
+NOTICE:  role "credtest" does not exist, skipping
+DROP EXTENSION credcheck CASCADE;
+CREATE EXTENSION credcheck;
+-- no password in the history, the extension has not been loaded
+CREATE USER credtest WITH PASSWORD 'AJ8YuRe=6O0';
+LOAD 'credcheck';
+SET credcheck.password_reuse_history = 1;
+SET credcheck.password_reuse_interval = 365;
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename | password_text 
+----------+---------------
+(0 rows)
+
+-- Add a new password in the history and set its age to 100 days
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+UPDATE credcheck.pg_auth_history SET password_date = now() - '100 days'::interval;
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename |                          password_text                           
+----------+------------------------------------------------------------------
+ credtest | e61e58c22aa6bf31a92b385932f7d0e4dbaba24fa3fdb2982510d6c72a961335
+(1 row)
+
+-- fail, the password is in the history for less than 1 year
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+ERROR:  Cannot use this credential following the password reuse policy
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename |                          password_text                           
+----------+------------------------------------------------------------------
+ credtest | e61e58c22aa6bf31a92b385932f7d0e4dbaba24fa3fdb2982510d6c72a961335
+(1 row)
+
+-- success, but the old password must be kept in the history (interval not reached)
+ALTER USER credtest PASSWORD 'AJ8YuRe=6O0';
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename |                          password_text                           
+----------+------------------------------------------------------------------
+ credtest | e61e58c22aa6bf31a92b385932f7d0e4dbaba24fa3fdb2982510d6c72a961335
+ credtest | 79320cea69ba581d5e17255c02ae08060f412f79a7c14d0e24ffca51fc03ec74
+(2 rows)
+
+-- fail, the password is still present in the history
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+ERROR:  Cannot use this credential following the password reuse policy
+-- Change the age of the password to exceed the 1 year interval
+UPDATE credcheck.pg_auth_history SET password_date = now() - '380 days'::interval;
+-- success, the old password present in the history has expired
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename |                          password_text                           
+----------+------------------------------------------------------------------
+ credtest | 79320cea69ba581d5e17255c02ae08060f412f79a7c14d0e24ffca51fc03ec74
+ credtest | e61e58c22aa6bf31a92b385932f7d0e4dbaba24fa3fdb2982510d6c72a961335
+(2 rows)
+
+-- Rename user, all entries in the history table must follow the change
+ALTER USER credtest RENAME TO credtest2;
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+ rolename  |                   password_text                   
+-----------+---------------------------------------------------
+ credtest2 | 9320cea69ba581d5e17255c02a
+ credtest2 | 61e58c22aa6bf31a92b385932f7d0e4dbaba24fa3fdb29825
+(2 rows)
+
+-- Dropping the user must empty the record in history table
+DROP USER credtest2;
+SELECT * FROM credcheck.pg_auth_history;
+ rolename | password_date | password_text 
+----------+---------------+---------------
+(0 rows)
+

--- a/test/sql/05_pg13_reuse_history.sql
+++ b/test/sql/05_pg13_reuse_history.sql
@@ -1,0 +1,1 @@
+05_reuse_history.sql

--- a/test/sql/05_reuse_history.sql
+++ b/test/sql/05_reuse_history.sql
@@ -1,0 +1,23 @@
+DROP USER IF EXISTS credtest;
+DROP EXTENSION credcheck CASCADE;
+CREATE EXTENSION credcheck;
+LOAD 'credcheck';
+SET credcheck.password_reuse_history = 2;
+-- When creating user the password must be stored in the history
+CREATE USER credtest WITH PASSWORD 'H8Hdre=S2';
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+-- fail, the credential is still in the history
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+-- eject the first credential from the history and add a new one
+ALTER USER credtest PASSWORD 'AJ8YuRe=6O0';
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+-- fail, the credential is still in the history
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+-- success, eject the second credential from the history and reuse the first one
+ALTER USER credtest PASSWORD 'H8Hdre=S2';
+-- success, the second credential has been removed from the history
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+-- Dropping the user must empty the record in history table
+DROP USER credtest;
+SELECT * FROM credcheck.pg_auth_history;

--- a/test/sql/06_pg13_reuse_interval.sql
+++ b/test/sql/06_pg13_reuse_interval.sql
@@ -1,0 +1,1 @@
+06_reuse_interval.sql

--- a/test/sql/06_reuse_interval.sql
+++ b/test/sql/06_reuse_interval.sql
@@ -1,0 +1,32 @@
+DROP USER IF EXISTS credtest;
+DROP EXTENSION credcheck CASCADE;
+CREATE EXTENSION credcheck;
+-- no password in the history, the extension has not been loaded
+CREATE USER credtest WITH PASSWORD 'AJ8YuRe=6O0';
+LOAD 'credcheck';
+SET credcheck.password_reuse_history = 1;
+SET credcheck.password_reuse_interval = 365;
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+-- Add a new password in the history and set its age to 100 days
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+UPDATE credcheck.pg_auth_history SET password_date = now() - '100 days'::interval;
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+-- fail, the password is in the history for less than 1 year
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+-- success, but the old password must be kept in the history (interval not reached)
+ALTER USER credtest PASSWORD 'AJ8YuRe=6O0';
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+-- fail, the password is still present in the history
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+-- Change the age of the password to exceed the 1 year interval
+UPDATE credcheck.pg_auth_history SET password_date = now() - '380 days'::interval;
+-- success, the old password present in the history has expired
+ALTER USER credtest PASSWORD 'J8YuRe=6O';
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+-- Rename user, all entries in the history table must follow the change
+ALTER USER credtest RENAME TO credtest2;
+SELECT rolename, password_text FROM credcheck.pg_auth_history ;
+-- Dropping the user must empty the record in history table
+DROP USER credtest2;
+SELECT * FROM credcheck.pg_auth_history;

--- a/updates/credcheck--0.2.0--1.0.0.sql
+++ b/updates/credcheck--0.2.0--1.0.0.sql
@@ -1,0 +1,22 @@
+-- credcheck extension for PostgreSQL
+-- Copyright (c) 2021-2023 MigOps Inc - All rights reserved.
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION credcheck" to load this file. \quit
+
+CREATE SCHEMA credcheck;
+
+----
+-- Table used to store the password reuse historic
+----
+CREATE TABLE credcheck.pg_auth_history
+(
+	rolename name NOT NULL,
+	password_date timestamp without time zone NOT NULL,
+	password_text text NOT NULL,
+	PRIMARY KEY (rolename, password_text)
+);
+CREATE INDEX ON credcheck.pg_auth_history(password_date, rolename);
+
+-- Include the table into pg_dump
+SELECT pg_catalog.pg_extension_config_dump('credcheck.pg_auth_history', '');


### PR DESCRIPTION
All users passwords are historicized in table (credcheck.pg_auth_history) together with the timestamps of when these passwords were set.

Two settings allow to control the behavior of this feature:

  - credcheck.password_reuse_history: number of distinct passwords set before a password can be reused.
  - credcheck.password_reuse_interval: amount of time it takes before a password can be reused again.

The default value for these settings are 0 which means that all password reuse policies are disabled.

The password history consists of passwords a user has been assigned in the past. credcheck can restrict new passwords from being chosen from this history:

  - If an account is restricted on the basis of number of password changes, a new password cannot be chosen from the password_reuse_history most recent passwords. For example, minimum number of password changes is set to 3, a new password cannot be the same as any of the most recent 3 passwords.

  - If an account is restricted based on time elapsed, a new password can't be chosen from those in the history that are newer than the number of day set to password_reuse_interval. For example, if the password reuse interval is set to 365, new password must not be among those previously chosen within the last year.

Thanks to Umair Shahid and Gabi201265 for the feature request.